### PR TITLE
Guard add remove stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ MultiRead.prototype.remove = function (stream) {
 }
 
 MultiRead.prototype.add = function (stream) {
+  if (this.destroyed) return
   this.streams.push(stream)
   this._add(stream)
   if (this._forward) this._read()

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ MultiRead.prototype.finalize = function () {
 
 MultiRead.prototype.remove = function (stream) {
   var i = this.streams.indexOf(stream)
+  if (i === -1) return
   this.streams.splice(i, 1)
   stream.removeListener('readable', this._onreadable)
   stream.removeListener('close', this._onclose)

--- a/test.js
+++ b/test.js
@@ -63,3 +63,29 @@ tape('add later', function (t) {
     t.end()
   }))
 })
+
+tape('remove existing', function (t) {
+  var a = from.obj(['a1'])
+  var b = from.obj(['a2', 'b2', 'c2'])
+
+  var rs = multi.obj([a, b])
+  rs.remove(a)
+
+  rs.pipe(concat({encoding: 'list'}, function (list) {
+    t.same(list, ['a2', 'b2', 'c2'], 'multi output')
+    t.end()
+  }))
+})
+
+tape('remove non-existing', function (t) {
+  var a = from.obj(['a1'])
+  var b = from.obj(['a2', 'b2', 'c2'])
+
+  var rs = multi.obj([b])
+  rs.remove(a)
+
+  rs.pipe(concat({encoding: 'list'}, function (list) {
+    t.same(list, ['a2', 'b2', 'c2'], 'multi output')
+    t.end()
+  }))
+})


### PR DESCRIPTION
Prevents throwing error when removing a stream that is not in the list. Also prevents adding streams once destroyed.